### PR TITLE
Exposing chunk-size as a parameter to write-riffle

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factual/riffle "0.1.3"
+(defproject factual/riffle "0.1.4"
   :description "a write-once key/value store"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -11,14 +11,17 @@
                    :stress :stress
                    :benchmark :benchmark}
   :profiles {:uberjar {:aot :all
-                       :dependencies [[org.clojure/clojure "1.7.0-alpha6"]]
+                       :dependencies [[org.clojure/clojure "1.7.0"]]
                        :main riffle.cli}
-             :dev {:dependencies [[org.clojure/clojure "1.7.0-alpha6"]
+             :dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/test.check "0.7.0"]
                                   [criterium "0.4.3"]]
                    :main riffle.cli}}
    :codox {:include [riffle.write
                      riffle.read]
-           :output-dir "doc"}
-   :plugins [[codox "0.8.10"]]
+           :output-dir "doc"
+           :defaults {:doc/format :markdown}
+           :src-dir-uri "https://github.com/Factual/riffle/blob/master/"
+           :src-linenum-anchor-prefix "L"}
+   :plugins [[codox "0.8.15"]]
    :jvm-opts ["-server" "-Xmx1g"])

--- a/src/riffle/data/riffle.clj
+++ b/src/riffle/data/riffle.clj
@@ -50,7 +50,7 @@
   (.createNewFile f))
 
 (defn write-riffle
-  [kvs x {:keys [sorted? compressor hash checksum block-size]}]
+  [kvs x {:keys [sorted? compressor hash checksum block-size chunk-size]}]
   (let [compress-fn (if (= :none compressor) identity #(bt/compress % compressor))
         hash-fn #(bt/hash % hash)
         checksum-fn #(bt/hash % checksum)
@@ -60,7 +60,7 @@
         count (atom 0)
         blocks (->> kvs
                  (map #(do (swap! count inc) %))
-                 (#(if sorted? % (s/sort-kvs (key-comparator hash-fn) 1e7 %)))
+                 (#(if sorted? % (s/sort-kvs (key-comparator hash-fn) chunk-size %)))
                  (b/kvs->blocks hash-fn block-size))
         slots (p/long (Math/ceil (/ @count t/load-factor)))
 

--- a/src/riffle/write.clj
+++ b/src/riffle/write.clj
@@ -29,7 +29,7 @@
           hash :murmur32
           checksum :crc32
           block-size 4096
-          chunk-size 1e7}
+          chunk-size 1e8}
      :as options}]
      (l/write-riffle kvs x
        {:sorted? sorted?

--- a/src/riffle/write.clj
+++ b/src/riffle/write.clj
@@ -13,28 +13,31 @@
 
    Available options:
 
-   sorted? - whether the input is presorted according to Riffle's hash sort-order, defaults to false
-   compressor - the compressor used to store blocks, defaults to :lz4, other valid options include :none, :snappy, :gzip
-   hash - the hash function used, defaults to :mumur32
-   checksum - the checksum function used, defaults to :crc32
-   blocksize - the maximum uncompressed block size in bytes, defaults to 4096"
+   - `sorted?` - whether the input is presorted according to Riffle's hash sort-order, defaults to false
+   - `compressor` - the compressor used to store blocks, defaults to :lz4, other valid options include :none, :snappy, :gzip
+   - `hash` - the hash function used, defaults to :mumur32
+   - `checksum` - the checksum function used, defaults to :crc32
+   - `blocksize` - the maximum uncompressed block size in bytes, defaults to 4096
+   - `chunk-size` - if sorting is needed, describes how much of the serialized sequence will be kept in memory before being flushed to disk for future merge-sorting, defaults to 1e7"
   ([kvs x]
      (write-riffle kvs x nil))
   ([kvs
     x
-    {:keys [sorted? compressor hash checksum block-size]
+    {:keys [sorted? compressor hash checksum block-size chunk-size]
      :or {sorted? false
           compressor :lz4
           hash :murmur32
           checksum :crc32
-          block-size 4096}
+          block-size 4096
+          chunk-size 1e7}
      :as options}]
      (l/write-riffle kvs x
        {:sorted? sorted?
         :compressor compressor
         :hash hash
         :checksum checksum
-        :block-size block-size})))
+        :block-size block-size
+        :chunk-size chunk-size})))
 
 (defn merge-riffles
   "Merges together a collection of Riffle files into a single index, writing out to `x`, which may either be a file path


### PR DESCRIPTION
Hello Zach, hello Factual,

first of all thanks for the riffle. It is a nice piece of software, I find it very useful.

I use it mostly as a library. For one of my apps I was getting notorious errors of the sort:

Exception in thread "main" java.io.FileNotFoundException: ./riffle4995446341518756004 (Too many open files)

on creating a riffle file. After a brief investigation, it turned out that the reason was in merge sort, which was creating very large number of temporary files for further merge. The easy fix, which seems reasonable for me, was to provide additional option to write-riflle, allowing for the control of chunk-size for merge sort (previously hardcoded to 1.0e7). I am attaching a fix, which made 
my life a lot easier ;)

What do you think about merging it to the main line?

Best regards,
Michał
